### PR TITLE
Suggested updates to message

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 
 ## mmt-metadata
 
-Using ssb to record metadata associated with multi-signature bitcoin transactions.  
+Using ssb to record metadata associated with multi-signature bitcoin transactions.
 
 Currently it is a work in progress.
 
@@ -11,7 +11,7 @@ Wallet software with multi-signature functionality such as Electrum do not allow
 
 ### What this project should do: (can be separated into smaller modules)
 
-- Use secure-scuttlebutt for sharing information between holders of the wallet. 
+- Use secure-scuttlebutt for sharing information between holders of the wallet.
 - Provide shared access to payment meta-data.
 - Provide a mechanism for sending and viewing partially signed transactions.
 - Provide a mechanism for sharing public keys when initiating the wallet.
@@ -26,34 +26,34 @@ This is only a proposal!  Its all subject to discussion and change...
 - All messages will be encrypted.
 - No main-net transaction data will be published until we have agreed it is secure.
 
-#### `initiateMmtMultisigTest` 
+#### `initiateMmtMultisigTest`
 
-This will be published one time per wallet by the person who initiates the wallet and will contain a name for the wallet, the number of required cosigners and one bitcoin public key.  The list of recipients for this message will remain the same for all future messages related to this wallet, and also defines the number of cosigners.
+This will be published one time per wallet by the person who initiates the wallet and will contain a name for the wallet `walletName`, the number of required cosigners `requiredCosigners` and one bitcoin public key `xpub`.  The list of recipients for this message will remain the same for all future messages related to this wallet, and also defines the number of cosigners.
 Example:
 ```
 content: {
   walletName: 'the groovy gang wallet',
   requiredCosigners: 2,
-  xpub: 'xpubblahblah....'
+  xpub: 'xpubblahblah111....'
 }
 ```
 
 #### `shareMmtPublicKeyTest`
 
-This will be published once per remaining group member to initiate the wallet.  It will contain the ssb message key of the relevant `initiateMmtMultisigTest` message, as well as one bitcoin public key.
+This will be published once per remaining group member to initiate the wallet.  It will contain the ssb message key of the relevant `initiateMmtMultisigTest` message `walletId`, as well as one bitcoin public key `xpub`.
 Example:
 ```
 content: {
   walletId: '%9t2AsdffVfrt9+PygOipJP6COtTUy7igJt/SjNWkYnR8=.sha256',
-  xpub: 'xpubblahblah.....'
+  xpub: 'xpubblahblah222.....'
 }
 ```
 
 #### `unsignedMmtPaymentTest`
 
-This will be published each time an outgoing payment needs to be signed.  In the case of only two signatures being required it will be published once per outgoing payment. It will contain a bitcoin transaction id, the raw unsigned transaction in hex, optionally the rate in another currency at the time of initiating, and optionally a description. 
+This will be published each time an outgoing payment needs to be signed.  In the case of only two signatures being required it will be published once per outgoing payment. It will contain: a link the `initiateMmtMultisigTest` ssb message `walletId`, a bitcoin transaction id `key`, the raw unsigned transaction in hex `rawTransaction`, optionally the rate `rate` in another currency `currency` at the time of initiating, and optionally a comment `comment`.
 
-Potentially an alias or unique indentifier could be associated with each receive address, but im not sure how to do this in a reliable way.
+Potentially an alias or unique identifier could be associated with each receive address, but im not sure how to do this in a reliable way.
 
 It could possibly also contain an identifier of the wallet, but it should be possible to derive this from the transaction data.
 
@@ -61,23 +61,37 @@ It could possibly also contain an identifier of the wallet, but it should be pos
 content: {
   walletId: '%9t2AsdffVfrt9+PygOipJP6COtTUy7igJt/SjNWkYnR8=.sha256',
   // is the transaction id needed?  it can also be derived from the transaction data
-  key: 'd5f2a6a8cd1e8c35466cfec16551', 
+  key: 'd5f2a6a8cd1e8c35466cfec16551',
   rawTransaction: 'a294b83........',
   rate:           5000,
+  currency:       'GBP',
   comment:       'bought a new pencil sharpener'
 }
 ```
 
 #### `addMmtPaymentCommentTest`
 
-This will be published any number of times to add notes and comments to payments.  This can also be extended to add extra functionality for specific use cases.  For example a payroll system could add the pay period dates and days worked.  It will contain a bitcoin transaction id, a comment, and optional extra information.
+This will be published any number of times to add notes and comments to payments.  This can also be extended to add extra functionality for specific use cases.  For example a payroll system could add the pay period dates and days worked.  It will contain: a link the `initiateMmtMultisigTest` ssb message `walletId`, a bitcoin transaction id `key`, a comment `comment`, and optional extra information.
 
 Example:
 ```
 content: {
   walletId: '%9t2AsdffVfrt9+PygOipJP6COtTUy7igJt/SjNWkYnR8=.sha256',
-  key: 'd5f2a6a8cd1e8c35466cfec16551', 
+  key: 'd5f2a6a8cd1e8c35466cfec16551',
   comment: 'this payment was a mistake'
+}
+```
+
+#### `signedMmtPaymentTest`
+
+This will be published each time a cosigner signs a payment. It will contain: a link the `initiateMmtMultisigTest` ssb message `walletId`, a bitcoin transaction id `key`, the hex of the signed transaction (?) `rawTransaction`.
+
+Example:
+```
+content: {
+  walletId: '%9t2AsdffVfrt9+PygOipJP6COtTUy7igJt/SjNWkYnR8=.sha256',
+  key: 'd5f2a6a8cd1e8c35466cfec16551',
+  rawTransaction: 'a294b83........',
 }
 ```
 
@@ -101,12 +115,12 @@ Setting up electrum is not yet automated, we will need to do:
 electrum --testnet setconfig rpcport 8888
 electrum --testnet setconfig rpcuser spinach
 electrum --testnet setconfig rpcpassword test
-electrum --testnet daemon start 
-electrum --testnet -w ~/.electrum/testnet/wallets/walletfile daemon load_wallet 
+electrum --testnet daemon start
+electrum --testnet -w ~/.electrum/testnet/wallets/walletfile daemon load_wallet
 ```
 and not to forget afterwards
 ```
-electrum --testnet daemon stop 
+electrum --testnet daemon stop
 ```
 
 ### Relevant resources
@@ -116,4 +130,4 @@ electrum --testnet daemon stop
 * [bitcoinjs-lib](https://github.com/bitcoinjs/bitcoinjs-lib)
 * [electrum json rpc interface](http://docs.electrum.org/en/latest/merchant.html#jsonrpc-interface)
 * [live.blockcypher.com/btc-testnet](https://live.blockcypher.com/btc-testnet/) - this is the testnet explorer im using.  If you know a better one, post it here
-* [mixmix/ssb-server-plugin-intro](https://github.com/mixmix/ssb-server-plugin-intro) 
+* [mixmix/ssb-server-plugin-intro](https://github.com/mixmix/ssb-server-plugin-intro)


### PR DESCRIPTION
When a tx is signed then it makes sense to publish the signed hex, then each client can verify that it was actually signed.  

I also added the `currency`.