### PR TITLE
Review wallet 'invites' and share master public keys

### DIFF
--- a/app/electron-interface.js
+++ b/app/electron-interface.js
@@ -503,3 +503,28 @@ electronInterface.initateWalletForm = function(server,ssbAbout,mpk) {
     );
   })
 }
+
+
+electronInterface.sharePubKeyForm = function (incompleteWallets,mpk) {
+  var numInvites = incompleteWallets.length
+  console.log(numInvites, " wallet Invite(s) Found.  Do you want to join?");
+  $("#notifications").append(
+    numInvites + "wallet invite(s) found."
+  );
+  // form where you can enter and publish public key (for now)
+  $("#sharePubKey").attr("class", "visible")
+  // display info on each invite
+  incompleteWallets.forEach( function(incompleteWallet){
+    //incompleteWallet.walletName
+    //incompleteWallet.requiredCosigners
+    //incompleteWallet.cosigners.length
+    //incompleteWallet.cosigners ( get names, and who has joined and who not)
+    //xpubs
+    //
+  } )
+  if (mpk) {
+    // if we have a wallet loaded, offer to join with this wallet
+  } else {
+    // offer to set up a new seed etc.
+  }
+}

--- a/app/index.js
+++ b/app/index.js
@@ -212,13 +212,7 @@ function aboutCallbackCreator(server, me) {
       // tidyWalletInfo()
 
       var incompleteWallets = util.findIncompleteWallets(dataFromSsb);
-      if (incompleteWallets.length > 0) {
-        console.log("Wallet Invite Found.  Do you want to join?");
-        $("#notifications").append(
-          "Wallet Invite Found."
-        );
-        // form where you can enter and publish public key (for now)
-      }
+        
 
       ec.checkVersion(requiredElectrumVersion, function(err, output) {
         if (err) {
@@ -226,7 +220,9 @@ function aboutCallbackCreator(server, me) {
           $("#notifications").append(
             "Error connecting to electrum.  Is the electrum daemon running, with a wallet loaded?"
           );
-          // offer to set up a new wallet 
+          if (incompleteWallets.length > 0) electronInterface.sharePubKeyForm(incompleteWallets,null)
+          //else
+          // offer to set up a new wallet (initWallet) 
         } else {
           if (output) {
             console.log("electrum version ok");
@@ -240,6 +236,8 @@ function aboutCallbackCreator(server, me) {
       });
       // Get master public key
       ec.getMpk(function(err, mpk) {
+        // TODO: handle the situation the daemon is running with no wallet loaded
+        if (err) throw (err)
         //var hashMpk = bitcoin.crypto.sha256(Buffer.from(mpk));
         console.log("-----mpk", mpk);
         wallet.walletId = util.identifyWallet(dataFromSsb, mpk);

--- a/app/util.js
+++ b/app/util.js
@@ -35,8 +35,9 @@ function identifyWallet(allWallets, mpk) {
 
 // todo: should this query be done within the ssb plugin?
 function findIncompleteWallets(allWallets) {
+  // should this better be an object, not array?
   var incompleteWallets = [];
-  console.log("allWallets", JSON.stringify(allWallets, null, 4));
+  // console.log("allWallets", JSON.stringify(allWallets, null, 4));
   Object.keys(allWallets).forEach(function(aWallet) {
     //TODO: should we do validation of correct keys here?
     if (


### PR DESCRIPTION
If we find one or more 'wallet invites' -that is, a wallet init message that is addressed to us but for which we have not published a master public key, display information and offer to join, either using the mpk of the currently loaded wallet or by creating a new seed and key.